### PR TITLE
[Bugfix] Update URLs to point to jqlang/jq instead of stedolan/jq.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![](https://github.com/AZMCode/asdf-jq/workflows/ci/badge.svg)
 
-[jq](https://stedolan.github.io/jq/) plugin for the [asdf](https://github.com/asdf-vm/asdf) version manager.
+[jq](https://jqlang.github.io/jq/) plugin for the [asdf](https://github.com/asdf-vm/asdf) version manager.
 
 ## Install
 

--- a/bin/download
+++ b/bin/download
@@ -9,8 +9,8 @@ plugin_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=../lib/utils.bash
 source "${plugin_dir}/../lib/utils.bash"
 
-declare -r JQ_REPO="https://github.com/stedolan/jq.git"
-declare -r RELEASES_URL="https://api.github.com/repos/stedolan/jq/releases"
+declare -r JQ_REPO="https://github.com/jqlang/jq.git"
+declare -r RELEASES_URL="https://api.github.com/repos/jqlang/jq/releases"
 
 
 error_exit() {

--- a/bin/help.overview
+++ b/bin/help.overview
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-echo "asdf-jq is an asdf-vm plugin to install, download or compile jq, a command-line JSON processing tool from stedolan."
+echo "asdf-jq is an asdf-vm plugin to install, download or compile jq, a command-line JSON processing tool."

--- a/bin/list-all
+++ b/bin/list-all
@@ -12,7 +12,7 @@ plugin_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=../lib/utils.bash
 source "${plugin_dir}/../lib/utils.bash"
 
-readonly RELEASES_URL="https://api.github.com/repos/stedolan/jq/releases"
+readonly RELEASES_URL="https://api.github.com/repos/jqlang/jq/releases"
 
 # https://github.com/rbenv/ruby-build/blob/ac92ec0507fad718e7abcf13540641937ecfef3f/bin/ruby-build#L1201
 sort_versions() {


### PR DESCRIPTION
It looks like the library organization in GitHub has changed, which breaks most of the operations in the plugin.

Test Plan:

- [x] `asdf list all jq` actually returns a list of versions after the change.
- [x] `asdf install jq 1.6` runs without error.