### PR TITLE
Actually download arm builds on arm if jq≥1.7

### DIFF
--- a/bin/download
+++ b/bin/download
@@ -34,9 +34,17 @@ get_arch(){
   if [ "$arch" == 'x86_64' ]; then
     echo '64'
   elif [ "$arch" == 'aarch64' ]; then
-    echo '64'
+    if echo $ASDF_INSTALL_VERSION | grep ^1\\.\[0-6\]; then
+      echo '64'
+    else
+      echo '-arm64'
+    fi
   elif [ "$arch" == 'arm64' ]; then
-    echo '64'
+    if echo $ASDF_INSTALL_VERSION | grep ^1\\.\[0-6\]; then
+      echo '64'
+    else
+      echo '-arm64'
+    fi
   elif [ "$arch" == 'i386' ]; then
     echo '32'
   elif [ "$arch" == 'i686' ]; then


### PR DESCRIPTION
The jq project [releases](https://github.com/jqlang/jq/releases/) since version 1.7 binaries compiled for arm. This is especially helpful on arm without the help of [Rosetta](https://en.wikipedia.org/wiki/Rosetta_(software)#Rosetta_2). In our case, we want to use it on CircleCI's with arm machines.

I haven't tested this on a Mac (since I don't own one).